### PR TITLE
fix report changeset

### DIFF
--- a/lib/elixero/core_api/models/reports/report/row.ex
+++ b/lib/elixero/core_api/models/reports/report/row.ex
@@ -1,20 +1,21 @@
 defmodule EliXero.CoreApi.Models.Reports.Report.Row do
-    use Ecto.Schema
-    import Ecto.Changeset
+  use Ecto.Schema
+  import Ecto.Changeset
 
-    @derive {Poison.Encoder, except: [:__meta__, :id]}
+  @derive {Poison.Encoder, except: [:__meta__, :id]}
 
-    schema "rows" do
-        field :RowType, :string
-        embeds_many :Cells, EliXero.CoreApi.Models.Reports.Report.Rows.Cell
-        field :Title, :string
-        embeds_many :Rows, EliXero.CoreApi.Models.Reports.Report.Row
-    end
+  schema "rows" do
+    field :RowType, :string
+    embeds_many :Cells, EliXero.CoreApi.Models.Reports.Report.Rows.Cell
+    field :Title, :string
+    embeds_many :Rows, EliXero.CoreApi.Models.Reports.Report.Row
+  end
 
-    def changeset(struct, data) do
-        struct
-        |> cast(data, [:RowType, :Title])
-        |> cast_embed(:Cells)
-        |> cast_embed(:Rows)
-    end
+  def changeset(struct, data) do
+    struct
+    |> cast(data, [:RowType, :Title])
+    |> cast_embed(:Cells)
+    |> cast_embed(:Rows)
+  end
 end
+

--- a/lib/elixero/core_api/models/reports/report/rows/cell.ex
+++ b/lib/elixero/core_api/models/reports/report/rows/cell.ex
@@ -1,17 +1,17 @@
 defmodule EliXero.CoreApi.Models.Reports.Report.Rows.Cell do
-    use Ecto.Schema
-    import Ecto.Changeset
-    
-    @derive {Poison.Encoder, except: [:__meta__, :id]}
+  use Ecto.Schema
+  import Ecto.Changeset
 
-    schema "cells" do
-        field :Value, :string
-        embeds_many :Attributes, EliXero.CoreApi.Models.Reports.Report.Rows.Cell.Attribute
-    end
+  @derive {Poison.Encoder, except: [:__meta__, :id]}
 
-    def changeset(struct, data) do
-        struct
-        |> cast(data, [:Value])
-        |> cast_embed(:Attributes)
-    end
+  schema "cells" do
+    field :Value, :string
+    embeds_many :Attributes, EliXero.CoreApi.Models.Reports.Report.Rows.Cell.Attribute
+  end
+
+  def changeset(struct, data) do
+    struct
+    |> cast(data, [:Value])
+    |> cast_embed(:Attributes)
+  end
 end

--- a/lib/elixero/core_api/models/reports/report/rows/cells/attribute.ex
+++ b/lib/elixero/core_api/models/reports/report/rows/cells/attribute.ex
@@ -1,16 +1,16 @@
 defmodule EliXero.CoreApi.Models.Reports.Report.Rows.Cell.Attribute do
-    use Ecto.Schema
-    import Ecto.Changeset
-    
-    @derive {Poison.Encoder, except: [:__meta__, :id]}
+  use Ecto.Schema
+  import Ecto.Changeset
 
-    schema "attributes" do
-        field :Value, :string
-        field :Id, :string
-    end
+  @derive {Poison.Encoder, except: [:__meta__, :id]}
 
-    def changeset(struct, data) do
-        struct
-        |> cast(data, [:field, :Id])
-    end
+  schema "attributes" do
+    field :Value, :string
+    field :Id, :string
+  end
+
+  def changeset(struct, data) do
+    struct
+    |> cast(data, [:Value, :Id])
+  end
 end


### PR DESCRIPTION
I fixed whitepace (which makes the PR look larger).
The relevant change is in `EliXero.CoreApi.Models.Reports.Report.Rows.Cell.Attribute`

```
 def changeset(struct, data) do
   struct
   |> cast(data, [:Value, :Id])
end
```