### PR TITLE
allow api config at runtime

### DIFF
--- a/lib/elixero/utils/http.ex
+++ b/lib/elixero/utils/http.ex
@@ -1,19 +1,22 @@
 defmodule EliXero.Utils.Http do
 
-  @user_agent "EliXero - " <> Application.get_env(:elixero, :consumer_key)
+  def user_agent do
+    "EliXero - " <> Application.get_env(:elixero, :consumer_key)
+  end
+
   @accept "application/json"
 
   @connection_timeout 330000
 
   def get(url, authorisation_header) do
 
-    {:ok, response} = HTTPoison.get url, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.get url, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
     response
   end
 
   def get(url, authorisation_header, extra_headers) do
-    headers = [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}] ++ extra_headers
+    headers = [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}] ++ extra_headers
 
     {:ok, response} = HTTPoison.get url, headers, [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
@@ -23,21 +26,21 @@ defmodule EliXero.Utils.Http do
   def put(url, authorisation_header, data_map) do
     {_, payload} = Poison.encode(data_map)
 
-    {:ok, response} = HTTPoison.put url, payload, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.put url, payload, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
-    response 
+    response
   end
 
   def post(url, authorisation_header, data_map) do
     {_, payload} = Poison.encode(data_map)
 
-    {:ok, response} = HTTPoison.post url, payload, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.post url, payload, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
     response
   end
 
   def delete(url, authorisation_header) do
-    {:ok, response} = HTTPoison.delete url, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.delete url, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
     response
   end
@@ -45,15 +48,15 @@ defmodule EliXero.Utils.Http do
   def post_multipart(url, authorisation_header, path_to_file, name) do
     # The Xero Files API grabs the filename out of the content-disposition header of the multipart file request.
     # Hackney sets this to be the filename from the path of the file. We need to override it
-    content_disposition_overload = "form-data; filename=\"" <> name <> "\"" 
+    content_disposition_overload = "form-data; filename=\"" <> name <> "\""
 
-    {:ok, response} = HTTPoison.post url, {:multipart, [{:file, path_to_file, [{"Content-Disposition", content_disposition_overload}]}]}, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.post url, {:multipart, [{:file, path_to_file, [{"Content-Disposition", content_disposition_overload}]}]}, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] ++ [{:proxy, "127.0.0.1:8888"}]
 
     handle_response(response)
   end
 
   def post_file(url, authorisation_header, path_to_file) do
-    {:ok, response} = HTTPoison.post url, {:file, path_to_file}, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", @user_agent}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
+    {:ok, response} = HTTPoison.post url, {:file, path_to_file}, [{"Authorization", authorisation_header}, {"Accept", @accept}, {"User-Agent", user_agent()}], [{:recv_timeout, @connection_timeout}] # ++ [{:proxy, "127.0.0.1:8888"}]
 
     response
   end

--- a/lib/elixero/utils/oauth.ex
+++ b/lib/elixero/utils/oauth.ex
@@ -1,8 +1,19 @@
 defmodule EliXero.Utils.Oauth do
-  @oauth_consumer_key Application.get_env(:elixero, :consumer_key)
-  @oauth_consumer_secret Application.get_env(:elixero, :consumer_secret)
-  @application_type Application.get_env(:elixero, :app_type)
-  @private_key Application.get_env(:elixero, :private_key_path)
+  def oauth_consumer_key do
+    Application.get_env(:elixero, :consumer_key)
+  end
+
+  def oauth_consumer_secret do
+    Application.get_env(:elixero, :consumer_secret)
+  end
+
+  def application_type do
+    Application.get_env(:elixero, :app_type)
+  end
+
+  def private_key do
+    Application.get_env(:elixero, :private_key_path)
+  end
 
   def create_auth_header(method, url, additional_params, token) do
     {base_string, oauth_params} = create_oauth_context(method, url, additional_params)
@@ -24,7 +35,7 @@ defmodule EliXero.Utils.Oauth do
     timestamp = :erlang.float_to_binary(Float.floor(:os.system_time(:milli_seconds) / 1000), [{:decimals, 0}])
 
     oauth_signing_params = [
-        oauth_consumer_key: @oauth_consumer_key,
+        oauth_consumer_key: oauth_consumer_key(),
         oauth_nonce: EliXero.Utils.Helpers.random_string(10),
         oauth_signature_method: signature_method(),
         oauth_version: "1.0",
@@ -42,7 +53,7 @@ defmodule EliXero.Utils.Oauth do
         params ++ query_params
       else
         params
-      end    
+      end
 
     params_with_extras = Enum.sort(params_with_extras)
 
@@ -51,7 +62,7 @@ defmodule EliXero.Utils.Oauth do
       URI.encode_www_form(url) <> "&" <>
       URI.encode_www_form(
         EliXero.Utils.Helpers.join_params_keyword(params_with_extras, :base_string)
-      ) 
+      )
 
     {base_string, params}
   end
@@ -65,7 +76,7 @@ defmodule EliXero.Utils.Oauth do
   end
 
   defp signature_method() do
-    case(@application_type) do
+    case(application_type()) do
       :private -> "RSA-SHA1"
       :public -> "HMAC-SHA1"
       :partner -> "RSA-SHA1"
@@ -75,7 +86,7 @@ defmodule EliXero.Utils.Oauth do
   defp rsa_sha1_sign(base_string) do
     hashed = :crypto.hash(:sha, base_string)
 
-    {:ok, body} = File.read @private_key
+    {:ok, body} = File.read private_key()
 
     [decoded_key] = :public_key.pem_decode(body)
     key = :public_key.pem_entry_decode(decoded_key)
@@ -86,8 +97,8 @@ defmodule EliXero.Utils.Oauth do
   defp hmac_sha1_sign(base_string, token) do
     key =
       case(token) do
-        nil -> @oauth_consumer_secret <> "&"
-        _ -> @oauth_consumer_secret <> "&" <> token["oauth_token_secret"]
+        nil -> oauth_consumer_secret() <> "&"
+        _ -> oauth_consumer_secret() <> "&" <> token["oauth_token_secret"]
       end
     signed = :crypto.hmac(:sha, key, base_string)
     URI.encode(Base.encode64(signed), &URI.char_unreserved?(&1))

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule EliXero.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.9.0"},
+      {:httpoison, "~> 0.9"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:poison, "~> 3.0"},
       {:ecto, "~> 2.1"}
@@ -30,10 +30,10 @@ defmodule EliXero.Mixfile do
   end
 
   defp package do
-    [ 
+    [
       maintainers: ["MJMortimer"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/MJMortimer/elixero"} 
+      links: %{"Github" => "https://github.com/MJMortimer/elixero"}
     ]
   end
 end


### PR DESCRIPTION
If you change the consumer_secret or key you needed to recompile. In cases where you want to provide it at runtime it was impossible. This allows you get set it in mix as before, but also change it at runtime.